### PR TITLE
PAY-1919 removing back link from case transaction page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccpay-web-component",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build payment-lib",

--- a/projects/payment-lib/package.json
+++ b/projects/payment-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccpay-web-component",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/payment-lib/src/lib/components/case-transactions/case-transactions.component.html
+++ b/projects/payment-lib/src/lib/components/case-transactions/case-transactions.component.html
@@ -1,11 +1,5 @@
 <div class="govuk-width-container">
-  <div class="govuk-breadcrumbs govuk-!-padding-bottom-1">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a [href]="'/ccd-search'"  class="govuk-back-link">Back to case search</a>
-      </li>
-    </ol>
-  </div>
+
   <main class="govuk-main-wrapper">
 
     <div class="govuk-grid-row">


### PR DESCRIPTION



### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PAY-1919

### Change description ###
Given a CTSC admin officer has conducted a search for a CCD case in PayBubble
And the case exists in CCD
When the are on the case transaction page

Then it is possible to return to the CCD case search and conduct a new search for a case


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
