### PR TITLE
PAY-2071 fix issue of fee amount is showing the calculated fee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccpay-web-component",
-  "version": "2.0.43",
+  "version": "2.0.44",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build payment-lib",

--- a/projects/payment-lib/package.json
+++ b/projects/payment-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccpay-web-component",
-  "version": "2.0.43",
+  "version": "2.0.44",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/payment-lib/src/lib/components/fee-summary/fee-summary.component.html
+++ b/projects/payment-lib/src/lib/components/fee-summary/fee-summary.component.html
@@ -46,7 +46,7 @@
           <table class="govuk-table">
             <tr class="govuk-table__row">
               <td class="no-border grey-text subcolumn-1">Fee amount:</td>
-              <td class="no-border subcolumn-2">{{ fee.calculated_amount | currency:'GBP':'symbol-narrow':'1.2-2' }}</td>
+              <td class="no-border subcolumn-2">{{ fee.calculated_amount/fee.volume | currency:'GBP':'symbol-narrow':'1.2-2' }}</td>
               <td class="no-border subcolumn-3"><a (click)="confirmRemoveFee(fee.id)">remove fee</a></td>
             </tr>
             <tr class="govuk-table__row" *ngIf="fee.volume && fee.volume > 0">


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PAY-2071


### Change description ###
After a fee has been selected for which there is a volume to be entered, after being entered, on the fee summary page the fee amount is showing the calculated fee amount rather than the fee unit price.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
