### PR TITLE
PAY-2190

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccpay-web-component",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build payment-lib",

--- a/projects/payment-lib/package.json
+++ b/projects/payment-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccpay-web-component",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/payment-lib/src/lib/components/payment-view/payment-view.component.ts
+++ b/projects/payment-lib/src/lib/components/payment-view/payment-view.component.ts
@@ -19,10 +19,13 @@ export class PaymentViewComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.ccdCaseNumber = this.paymentLibComponent.CCD_CASE_NUMBER;
     this.paymentViewService.getPaymentGroupDetails(this.paymentLibComponent.paymentGroupReference,
       this.paymentLibComponent.paymentMethod).subscribe(
-      paymentGroup => this.paymentGroup = paymentGroup,
+      paymentGroup => {
+        this.paymentGroup = paymentGroup;
+        this.paymentGroup.payments = this.paymentGroup.payments.filter
+        (paymentGroupObj => paymentGroupObj['reference'].includes(this.paymentLibComponent.paymentReference));
+      },  
       (error: any) => this.errorMessage = error
     );
   }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PAY-2190

### Change description ###

The payments detail page that is being displayed for a selected payment reference in PayBubble is showing the payment details for the first payment reference in the payment group and not the specified payment reference.

With this fix this issue is resolved.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
