### PR TITLE
Pay 6479 total fees left to pay third attempt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccpay-web-component",
-  "version": "6.1.4",
+  "version": "6.1.7-beta01",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build payment-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccpay-web-component",
-  "version": "6.2.0",
+  "version": "6.1.10",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build payment-lib",

--- a/projects/payment-lib/package.json
+++ b/projects/payment-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccpay-web-component",
-  "version": "6.2.0",
+  "version": "6.1.10",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/payment-lib/package.json
+++ b/projects/payment-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccpay-web-component",
-  "version": "6.1.4",
+  "version": "6.1.7-beta01",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/payment-lib/src/lib/components/service-request/service-request.component.html
+++ b/projects/payment-lib/src/lib/components/service-request/service-request.component.html
@@ -121,7 +121,7 @@
 
    <!--Payments-->
   <ng-container *ngFor="let order of orderDetail;" >
-   <div class="govuk-grid-column-full" *ngIf="order.payments">
+   <div class="govuk-grid-column-full" *ngIf="order.payments && hasPaymentRole()">
       <h3 class="heading-medium">{{ "Payments" | rpxTranslate }}</h3>
    <table class="govuk-table ">
       <thead class="govuk-table__head">
@@ -154,14 +154,9 @@
   </div>
 </div>
 </ng-container>
-<div *ngIf="isServiceRequest === 'false'">
-  <div *ngIf="((orderFeesTotal - orderRemissionTotal)- orderTotalPayments) > 0" >
-      <p class="totalPay">{{ "Total left to pay" | rpxTranslate }}: <b>{{((orderFeesTotal - orderRemissionTotal)- orderTotalPayments )| currency:'GBP':'symbol-narrow':'1.2-2' }}</b> </p>
+  <div>
+      <p class="totalPay">{{ "Total fees left to pay" | rpxTranslate }}: <b>{{((orderFeesTotal - orderRemissionTotal)- orderTotalPayments )| currency:'GBP':'symbol-narrow':'1.2-2' }}</b> </p>
   </div>
-  <div *ngIf="((orderFeesTotal - orderRemissionTotal)- orderTotalPayments) < 0" >
-      <p class="totalPay">{{"Total left to pay" | rpxTranslate }}: <b>0</b> </p>
-  </div>
-</div>
 </ng-container>
 
 <ccpay-add-remission *ngIf="viewStatus === 'addremission' && feeId"

--- a/projects/payment-lib/src/lib/components/service-request/service-request.component.html
+++ b/projects/payment-lib/src/lib/components/service-request/service-request.component.html
@@ -121,7 +121,7 @@
 
    <!--Payments-->
   <ng-container *ngFor="let order of orderDetail;" >
-   <div class="govuk-grid-column-full" *ngIf="order.payments && hasPaymentRole()">
+   <div class="govuk-grid-column-full" *ngIf="order.payments && hasPaymentsRole()">
       <h3 class="heading-medium">{{ "Payments" | rpxTranslate }}</h3>
    <table class="govuk-table ">
       <thead class="govuk-table__head">

--- a/projects/payment-lib/src/lib/components/service-request/service-request.component.ts
+++ b/projects/payment-lib/src/lib/components/service-request/service-request.component.ts
@@ -455,7 +455,7 @@ export class ServiceRequestComponent implements OnInit {
     this.notificationPreview = false;
   }
 
-  hasPaymentRole(): boolean {
+  hasPaymentsRole(): boolean {
     return this.LOGGEDINUSERROLES.includes('payments');
   }
 }

--- a/projects/payment-lib/src/lib/components/service-request/service-request.component.ts
+++ b/projects/payment-lib/src/lib/components/service-request/service-request.component.ts
@@ -454,4 +454,8 @@ export class ServiceRequestComponent implements OnInit {
   hideNotificationPreview(): void {
     this.notificationPreview = false;
   }
+
+  hasPaymentRole(): boolean {
+    return this.LOGGEDINUSERROLES.includes('payments');
+  }
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-6479


### Change description ###
Field has been renamed as 'Total fees left to pay'.
This release has an associated release of payments api that loosens the permissions for paymentgroups so users without the payments role can still have access to payments, so that the calculation for remaining fees is correct. As a consequence of this, the payments table needs to be conditional on the payments role, otherwise it would be showing up for users without the payments role.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
