### PR TITLE
Cme 501

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccpay-web-component",
-  "version": "6.2.14-beta3",
+  "version": "6.2.14-beta4",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build payment-lib",

--- a/projects/payment-lib/package.json
+++ b/projects/payment-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccpay-web-component",
-  "version": "6.2.14-beta3",
+  "version": "6.2.14-beta4",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/payment-lib/src/lib/components/add-remission/add-remission.component.ts
+++ b/projects/payment-lib/src/lib/components/add-remission/add-remission.component.ts
@@ -1273,13 +1273,21 @@ export class AddRemissionComponent implements OnInit {
   }
 
   getRemissions(feeCode: string): IRemission {
-    let myRemission = this.paymentLibComponent.paymentGroup.remissions.filter(remission => remission.fee_code === feeCode);
+    let myRemission = this.paymentGroupData.remissions.filter(remission => remission.fee_code === feeCode);
     if (myRemission.length == 0) {
       return null;
     }
     // We  can have one remission per case, only
     return myRemission.at(0);
   }
+
+  get paymentGroupData(): IPaymentGroup {
+    if (!this.paymentLibComponent.paymentGroup) {
+      this.paymentLibComponent.addPaymentGroup(this.paymentGroup);
+    }
+    return this.paymentLibComponent.paymentGroup;
+  }
+
 
   getRemissionsHwfAmount(feeCode: string): string {
     let myRemission = this.getRemissions(feeCode);


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/CME-501

### Change description

After the angular upgrade, the getRemissions method has started to fail due to a missing paymentGroup.  I have added in a getter method, that will return the paymentGroup, if it is not present, it will set it in line with how it is set in other places. 

### Testing done

This is resolving the display issue and the errors encounterd in the console logs.   The Process refund page is now rendering as expected.  

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
