### PR TITLE
PAY-6997 add a userRoleService to check locally for any payment roles…

### DIFF
--- a/projects/payment-lib/src/lib/payment-lib.component.ts
+++ b/projects/payment-lib/src/lib/payment-lib.component.ts
@@ -8,6 +8,7 @@ import {IRefundList} from "./interfaces/IRefundList";
 import {IFee} from "./interfaces/IFee";
 import {IRemission} from "./interfaces/IRemission";
 import {AddRetroRemissionRequest} from "./interfaces/AddRetroRemissionRequest";
+import {UserRoleService} from "./services/user-role.service";
 
 @Component({
   selector: 'ccpay-payment-lib',
@@ -120,7 +121,8 @@ export class PaymentLibComponent implements OnInit {
 
   constructor(private paymentLibService: PaymentLibService,
     private cd: ChangeDetectorRef,
-    private OrderslistService: OrderslistService) { }
+    private OrderslistService: OrderslistService,
+    private userRoleService: UserRoleService) { }
   ngAfterContentChecked(): void {
     this.cd.detectChanges();
   }
@@ -135,6 +137,7 @@ export class PaymentLibComponent implements OnInit {
     this.paymentLibService.setCardPaymentReturnUrl(this.CARDPAYMENTRETURNURL);
 
     if (this.LOGGEDINUSERROLES.length > 0) {
+      this.userRoleService.setRoles(this.LOGGEDINUSERROLES);
       this.OrderslistService.setUserRolesList(this.LOGGEDINUSERROLES);
     }
     if (this.PAYMENT_GROUP_REF) {

--- a/projects/payment-lib/src/lib/services/shared/httpclient/webcomponent.http.client.ts
+++ b/projects/payment-lib/src/lib/services/shared/httpclient/webcomponent.http.client.ts
@@ -1,36 +1,43 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import { Meta } from '@angular/platform-browser';
-import { Observable } from 'rxjs';
+import {Observable, throwError} from 'rxjs';
+import {UserRoleService} from "../../user-role.service";
 
 @Injectable()
 export class WebComponentHttpClient {
   constructor(
     private http: HttpClient,
-    private meta: Meta
+    private meta: Meta,
+    private userRoleService: UserRoleService
   ) { }
 
   post(url: string, body: any | null, options?: any): Observable<any> {
+    this.checkRolesOrThrow();
     const opts = this.addHeaders(options || {});
     return this.http.post(url, body, opts);
   }
 
   put(url: string, body: any | null, options?: any): Observable<any> {
+    this.checkRolesOrThrow();
     const opts = this.addHeaders(options || {});
     return this.http.put(url, body, opts);
   }
 
   get(url: string, options?: any): Observable<any> {
+    this.checkRolesOrThrow();
     const opts = this.addHeaders(options || {});
     return this.http.get(url, opts);
   }
 
   delete(url: string, options?: any): Observable<any> {
+    this.checkRolesOrThrow();
     const opts = this.addHeaders(options || {});
     return this.http.delete(url, opts);
   }
-  
+
   patch(url: string, body: any | null, options?: any): Observable<any> {
+    this.checkRolesOrThrow();
     const opts = this.addHeaders(options || {});
     return this.http.patch(url, body, opts);
   }
@@ -38,7 +45,7 @@ export class WebComponentHttpClient {
   addHeaders(options: any): any {
     const csrfToken = this.meta.getTag('name=csrf-token');
     const headers = {};
-    
+
     if (options.headers) {
       options.headers.forEach(element => {
         headers[element] = options.headers.get(element);
@@ -47,16 +54,29 @@ export class WebComponentHttpClient {
     headers['X-Requested-With'] = 'XMLHttpRequest';
     if (csrfToken === null) {
       if( document.cookie.split(';').find(row => row.startsWith('XSRF-TOKEN')) !== undefined ) {
-        headers['CSRF-Token'] = document.cookie.split(';').find(row => row.startsWith('XSRF-TOKEN')).split('=')[1];     
+        headers['CSRF-Token'] = document.cookie.split(';').find(row => row.startsWith('XSRF-TOKEN')).split('=')[1];
       } else {
         headers['CSRF-Token'] = document.cookie.split(';').find(row => row.startsWith(' XSRF-TOKEN')).split('=')[1];
       }
-      
+
     } else {
       headers['CSRF-Token'] = csrfToken.content;
     }
     options.headers = new HttpHeaders(headers);
     options.responseType = 'text';
     return options;
+  }
+
+  private checkRolesOrThrow(): Observable<void> | null {
+
+    if (this.userRoleService.hasAnyPaymentRole()) {
+      return throwError(() => new HttpErrorResponse({
+        status: 403,
+        statusText: 'Forbidden',
+        error: { message: `Access denied. Payment role required`}
+      }));
+    }
+
+    return null;
   }
 }

--- a/projects/payment-lib/src/lib/services/user-role.service.spec.ts
+++ b/projects/payment-lib/src/lib/services/user-role.service.spec.ts
@@ -1,0 +1,99 @@
+import { TestBed } from '@angular/core/testing';
+import { UserRoleService } from './user-role.service';
+
+describe('UserRoleService', () => {
+  let service: UserRoleService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserRoleService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('setRoles and getRoles', () => {
+    it('should set and get roles correctly', () => {
+      const roles = ['solicitor', 'caseworker'];
+      service.setRoles(roles);
+      expect(service.getRoles()).toEqual(roles);
+    });
+
+    it('should handle undefined roles gracefully in setRoles', () => {
+      service.setRoles(undefined);
+      expect(service.getRoles()).toEqual([]);
+    });
+  });
+
+  describe('hasRole', () => {
+    beforeEach(() => {
+      service.setRoles(['solicitor', 'payments-refund', 'caseworker']);
+    });
+
+    it('should return true if role exists', () => {
+      expect(service.hasRole('solicitor')).toBeTrue();
+      expect(service.hasRole('payments-refund')).toBeTrue();
+    });
+
+    it('should return false if role does not exist', () => {
+      expect(service.hasRole('superuser')).toBeFalse();
+      expect(service.hasRole('payment')).toBeFalse(); // partial match should fail
+    });
+  });
+
+  describe('hasAnyRole', () => {
+    beforeEach(() => {
+      service.setRoles(['solicitor', 'caseworker']);
+    });
+
+    it('should return true if at least one role matches', () => {
+      const result = service.hasAnyRole(['admin', 'solicitor']);
+      expect(result).toBeTrue();
+    });
+
+    it('should return false if none of the roles match', () => {
+      const result = service.hasAnyRole(['admin', 'superuser']);
+      expect(result).toBeFalse();
+    });
+
+    it('should return false if requiredRoles is empty', () => {
+      const result = service.hasAnyRole([]);
+      expect(result).toBeFalse();
+    });
+
+    it('should return false if roles are unset in the service', () => {
+      service.setRoles(undefined);
+      const result = service.hasAnyRole(['solicitor']);
+      expect(result).toBeFalse();
+    });
+
+    it('should return false if roles in the service are empty', () => {
+      service.setRoles([]);
+      const result = service.hasAnyRole(['solicitor']);
+      expect(result).toBeFalse();
+    });
+  });
+
+  describe('hasAnyPaymentRole', () => {
+    it('should return true if any role starts with "payment"', () => {
+      service.setRoles(['caseworker', 'payments-refund', 'solicitor']);
+      expect(service.hasAnyPaymentRole()).toBeTrue();
+    });
+
+    it('should return false if no role starts with "payment"', () => {
+      service.setRoles(['caseworker', 'solicitor']);
+      expect(service.hasAnyPaymentRole()).toBeFalse();
+    });
+
+    it('should return false if roles array is empty', () => {
+      service.setRoles([]);
+      expect(service.hasAnyPaymentRole()).toBeFalse();
+    });
+
+    it('should return false if roles array is undefined', () => {
+      service.setRoles(undefined);
+      expect(service.hasAnyPaymentRole()).toBeFalse();
+    });
+  });
+});

--- a/projects/payment-lib/src/lib/services/user-role.service.ts
+++ b/projects/payment-lib/src/lib/services/user-role.service.ts
@@ -1,0 +1,26 @@
+import {Injectable} from '@angular/core';
+
+@Injectable({providedIn: 'root'})
+export class UserRoleService {
+  private roles: string[] = [];
+
+  setRoles(roles: string[] | undefined): void {
+    this.roles = roles ?? [];
+  }
+
+  getRoles(): string[] {
+    return this.roles;
+  }
+
+  hasAnyPaymentRole(): boolean {
+    return this.roles?.some(role => role.startsWith('payment')) ?? false;
+  }
+
+  hasRole(role: string): boolean {
+    return this.roles.some(r => r.includes(role));
+  }
+
+  hasAnyRole(requiredRoles: string[]): boolean {
+    return requiredRoles.some(role => this.hasRole(role));
+  }
+}


### PR DESCRIPTION
… before forcing an unnecessary 403 from payments api

### Jira link

See [PAY-6997](https://tools.hmcts.net/jira/browse/PAY-6997)

### Change description

A new service called userRoleService to try and reduce the number of 403s that payments-api is returning from users of the web-component that do not have any payments role. These kind of role checks are already taking place throughout about a dozen of the components within the web-component but they are all duplications of the same line of code e.g 
```
if(this.LOGGEDINUSERROLES.some(i =>i.includes('payments-refund-approver'))){
      //
    } else {
      //
    }
```
This PR introduces a UserRoleService which could be used to replace this lines with:
`this.userRoleService.hasRole('payments-refund-approver')`
By extracting this logic to a new service we should be able to improve test coverage.
For now, I havn't replaced any role checking but I have added calls to this.userRoleService.hasAnyPaymentRole() in WebComponentHttpClient for each of the http methods e.g get, post, put.
This should prevent unnecessary calls to payments-api that would only be rejected with a 403.
The library throws a 403 locally.
### Testing done

New unit test class and local testing with XUI.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
